### PR TITLE
update to default curvenote deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,14 +16,8 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 20.2.0
-          check-latest: true
-      - run: npm install
+    steps:
       - name: Deploy 🚀
         uses: curvenote/action-myst-publish@v1
         env:
-          CURVENOTE_TOKEN: ${{ secrets.CURVENOTE_API }}
+          CURVENOTE_TOKEN: ${{ secrets.CURVENOTE_TOKEN }}


### PR DESCRIPTION
The current version of `mystmd` is generates the following workflow, that does not require explicit checkout or node installation steps.

Certainly npm commands like `npm ci`, `npm test` etc should not be run in the workflow, as there is no local `package.json` in this repo.

I'd suggest reverting to this and debugging any issues from there.